### PR TITLE
parse private registry image names

### DIFF
--- a/docker/client.go
+++ b/docker/client.go
@@ -99,7 +99,7 @@ func (d *dockerClient) FetchContainer(name, image string) (*Container, error) {
 		}
 
 		// These should match or else it's from an image that is not tagged
-		if image != "" && utils.RemoveTag(image) != container.Config.Image {
+		if image != "" && utils.RemoveTag(image) != utils.RemoveTag(container.Config.Image) {
 			return nil, ErrImageNotTagged
 		}
 		container.Image = image

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -11,8 +11,19 @@ func Truncate(name string) string {
 	return name
 }
 
+func checkTag(name string) (bool, int) {
+	index := strings.LastIndex(name, ":")
+	if index == -1 || strings.Contains(name[index:], "/") {
+		return false, -1
+	}
+	return true, index
+}
+
 func RemoveTag(name string) string {
-	return strings.Split(name, ":")[0]
+	if hasTag, index := checkTag(name); hasTag {
+		return name[:index]
+	}
+	return name
 }
 
 func RemoveSlash(name string) string {
@@ -20,9 +31,9 @@ func RemoveSlash(name string) string {
 }
 
 func CleanImageImage(name string) string {
-	parts := strings.Split(name, "/")
+	parts := strings.SplitN(name, "/", 2)
 	if len(parts) == 1 {
 		return RemoveSlash(RemoveTag(name))
 	}
-	return RemoveSlash(RemoveTag(parts[1]))
+	return CleanImageImage(parts[1])
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -15,9 +15,53 @@ func TestTruncateName(t *testing.T) {
 	}
 }
 
+func TestRemoveTag(t *testing.T) {
+	var (
+		name     = "crosbymichael/redis:latest"
+		expected = "crosbymichael/redis"
+	)
+
+	if actual := RemoveTag(name); actual != expected {
+		t.Fatalf("Expected %s go %s", expected, actual)
+	}
+}
+
+func TestRemoveTagWithRegistry(t *testing.T) {
+	var (
+		name     = "registry:5000/crosbymichael/redis:latest"
+		expected = "registry:5000/crosbymichael/redis"
+	)
+
+	if actual := RemoveTag(name); actual != expected {
+		t.Fatalf("Expected %s got %s", expected, actual)
+	}
+}
+
+func TestRemoveTagWithRegistryNoTag(t *testing.T) {
+	var (
+		name     = "registry:5000/crosbymichael/redis"
+		expected = "registry:5000/crosbymichael/redis"
+	)
+
+	if actual := RemoveTag(name); actual != expected {
+		t.Fatalf("Expected %s got %s", expected, actual)
+	}
+}
+
 func TestCleanImageName(t *testing.T) {
 	var (
 		name     = "crosbymichael/redis:latest"
+		expected = "redis"
+	)
+
+	if actual := CleanImageImage(name); actual != expected {
+		t.Fatalf("Expected %s got %s", expected, actual)
+	}
+}
+
+func TestCleanImageNameWithRegistry(t *testing.T) {
+	var (
+		name     = "registry:5000/crosbymichael/redis:latest"
 		expected = "redis"
 	)
 


### PR DESCRIPTION
Allow the use of images from a private registry.

Adjust the non-tagged image check because container.Config.Image will contain a tag if supplied to docker run.
i.e. docker run user/image:tag
