### PR TITLE
Example Nginx configuration, resolves services at runtime.

### DIFF
--- a/contrib/nginx.conf
+++ b/contrib/nginx.conf
@@ -1,0 +1,46 @@
+worker_processes 1;
+
+# in order to use `docker logs`
+error_log stderr;
+
+events {
+    worker_connections 1024;
+    use epoll;
+}
+
+http {
+
+    # tells nginx to use the skydns resolver
+    resolver 172.17.42.1 valid=5s;
+    resolver_timeout 5s;
+
+    server {
+        # your usual stuff
+        listen 80;
+        server_name kswizz.com *.kswizz.com;
+        root /app;
+
+        # so, nginx is stupid. we need to fool it into thinking
+        # that the proxy upstream is a runtime variable (e.g.
+        # it could be based off a $http_* variable.) this is the
+        # only way that triggers to use the resolver at runtime.
+        
+        set $dns app-1.ruby.live.docker;
+
+
+        # let's say we have two locations, the first of which
+        # proxies to a web-app service
+        
+        location /api {
+            rewrite ^/api/?(.*) /$1 break;
+            
+            # and here, we simply use our previously defined variable.
+            proxy_pass http://$dns:80;
+        }
+
+        location / {
+            try_files $uri /index.html;
+        }
+    }
+}
+


### PR DESCRIPTION
We have to jump through a few hoops in order to fool nginx into resolving upstream domains at runtime, instead of immediately when it parses the configuration file.
