### PR TITLE
Support proxy requests via SRV records

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,11 @@ docker run -d -v /var/run/docker.sock:/docker.sock -v /myplugins.js:/myplugins.j
 
 Feel free to submit your plugins to this repo under the `plugins/` directory.  
 
+#### Hipache Support
+If you pass in a host:port to connect to a running Hipache's Redis instance, SkyDock will manage your containers' availability in your Hipache instance.  In order to make this work, you need to follow some conventions:
+
+* Your containers must be named to match the public URL you intend to expose in Hipache eg: crosbymichael/www.crosbymichael.com
+* ? more conventions to follow?
 
 #### TODO/ROADMAP
 * Multihost support

--- a/hipache.go
+++ b/hipache.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"github.com/crosbymichael/skydock/docker"
+	"github.com/garyburd/redigo/redis"
+)
+
+func removeFromRedis(*docker.Event) err {
+
+}
+
+func addToRedis(*docker.Event) err {
+
+}


### PR DESCRIPTION
Here's an outline of a way to support adding and removing containers from a running hipache instance.  It isn't implemented yet, but presented here as a discussion topic.  Let me know what you think about the approach, whether this fits in SkyDock proper, whether it should be implemented as a plugin somewhere, or whether I should just keep it in a fork.

The ultimate goal is to allow you to add new containers directly to hipache by simply starting containers.  The container's name will be used as the public URL in hipache.

What about containers we don't want added to hipache?  My url naming convention won't help there.
