### PR TITLE
Use direct container name lookup instead of link

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Now that skydns is running we can start skydock what bridges the gap between doc
 
 ```bash
 docker pull crosbymichael/skydock
-docker run -d -v /var/run/docker.sock:/docker.sock --name skydock --link skydns:skydns crosbymichael/skydock -ttl 30 -environment dev -s /docker.sock -domain docker
+docker run -d -v /var/run/docker.sock:/docker.sock --name skydock crosbymichael/skydock -ttl 30 -environment dev -s /docker.sock -domain docker -name skydns
 ```
 
 


### PR DESCRIPTION
Add "-name" option to skydock to look up the skydns container by name.
This avoids having to manage Docker container links.

Docker's --link is still supported.
