### PR TITLE
Improve robustness under high system load.

### DIFF
--- a/main.go
+++ b/main.go
@@ -117,8 +117,8 @@ func heartbeat(uuid string) {
 	var errorCount int
 	for _ = range time.Tick(time.Duration(beat) * time.Second) {
 		if errorCount > 10 {
-			// if we encountered more than 10 errors just quit
-			log.Logf(log.ERROR, "aborting heartbeat for %s after 10 errors", uuid)
+			// if we encountered more than sequential 10 errors just quit
+			log.Logf(log.ERROR, "aborting heartbeat for %s after sequential 10 errors", uuid)
 			return
 		}
 
@@ -130,7 +130,11 @@ func heartbeat(uuid string) {
 
 		if err := updateService(uuid, ttl); err != nil {
 			errorCount++
-			log.Logf(log.ERROR, "%s", err)
+			log.Logf(log.ERROR, "updateService(): %s", err)
+		} else {
+			if errorCount--; errorCount < 0 {
+				errorCount = 0
+			}
 		}
 	}
 }


### PR DESCRIPTION
I had an issue where the skydock heartbeat goroutine would stop sending TTL updates to skydns because of the 'break' after an error (EOF and network hiccups under high system load).

This set of patches removes that break and adjusts errorCount to allow for brief periods of transient errors.

Testing showed that skydock was able to maintain registered skydns services even through stress testing using these patches and a more forgiving TTL `-ttl 120` and aggressive beat `-beat 15`.

Another level of improvement might be to to have skydock check with skydns.Get(uuid) and re-register any services that may have been lost due to a missed heartbeat.

Thanks!
