### PR TITLE
Use --bip setting to configure bridge IP.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ nameserver to that IP.  For this example we will use the ip `172.17.42.1` as the
 
 ```bash
 # start your daemon with the -dns flag, figure it out...
-docker -d -dns 172.17.42.1 # + what other settings you use
+docker -d --bip=172.17.42.1/16 --dns=172.17.42.1 # + what other settings you use
 ```
 
 **Note:**


### PR DESCRIPTION
Instead of guessing the IP, we could just make sure the IP matched DNS.
